### PR TITLE
Handle invalid detections gracefully

### DIFF
--- a/new_detect.py
+++ b/new_detect.py
@@ -188,9 +188,7 @@ def run_cycle(num_frames=NUM_FRAMES):
             log(f"P_t coords: {pt}")
             log(f"P_b coords: {pb}")
         else:
-            log("Invalid or distant coordinate detected. Restarting cycle.")
-            P_t_list.clear()
-            P_b_list.clear()
+            log("Invalid or distant coordinate detected. Skipping frame.")
             continue
 
     latest_frames['vis'] = last_vis


### PR DESCRIPTION
## Summary
- keep accumulating valid points instead of clearing the buffers in `run_cycle`

## Testing
- `python -m py_compile new_detect.py detect_apriltag_left.py calibrate_tilt_apriltag.py debug_disparity.py`


------
https://chatgpt.com/codex/tasks/task_e_68448be7b1448321ba1b4b3cd07413fc