### PR TITLE
Switch to AprilTag detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ are displayed in separate windows.
 
 The repository also includes ``detect_apriltag_left.py`` and
 ``calibrate_tilt_apriltag.py`` for working with AprilTags. These helpers are
-configured for the ``tagStandard41h12`` family and expect a tag measuring
-41&nbsp;mm across.
+configured for the ``tagStandard36h11`` family and expect a tag measuring
+36.5&nbsp;mm across.
 
 Additional Arduino sketches would control the mechanical actuators that move the
 robotic arm and gripper.

--- a/calibrate_tilt_apriltag.py
+++ b/calibrate_tilt_apriltag.py
@@ -3,8 +3,8 @@
 
 This script detects an AprilTag using the on-board cameras and computes the
 rotation angles (roll, pitch, yaw) that transform coordinates from the camera
-frame to the gripper frame.  It assumes a tag from the ``tagStandard41h12``
-family with a side length of 41 mm.
+frame to the gripper frame.  It assumes a tag from the ``tagStandard36h11``
+family with a side length of 36.5 mm.
 
 OpenCV with the ``aruco`` module must be available along with access to a
 camera.
@@ -30,9 +30,9 @@ D_R = np.array([-0.559392, 0.869527, -0.0131288, -0.00425451, -1.42753])
 # -----------------------------------------------------------------------------
 # AprilTag detector configuration
 # -----------------------------------------------------------------------------
-# The AprilTag is 41 mm wide and uses the tagStandard41h12 family.
-TAG_SIZE = 0.041  # side length in meters
-DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_APRILTAG_41h12)
+# The AprilTag is 36.5 mm wide and uses the tagStandard36h11 family.
+TAG_SIZE = 0.0365  # side length in meters
+DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_APRILTAG_36H11)
 PARAMS = cv2.aruco.DetectorParameters()
 DETECTOR = cv2.aruco.ArucoDetector(DICT, PARAMS)
 

--- a/detect_apriltag_left.py
+++ b/detect_apriltag_left.py
@@ -2,8 +2,8 @@
 """Preview the left camera feed and highlight AprilTag detections.
 
 This script opens the left camera, attempts to detect an AprilTag and displays
-the result live. It is configured for the ``tagStandard41h12`` family and
-expects a printed tag that is 41 mm wide. Press 'q' in the display window to
+the result live. It is configured for the ``tagStandard36h11`` family and
+expects a printed tag that is 36.5 mm wide. Press 'q' in the display window to
 quit.
 """
 
@@ -14,15 +14,14 @@ import time
 CAM_INDEX = 2  # device index for the left camera
 FRAME_WIDTH = 640
 FRAME_HEIGHT = 480
-TAG_SIZE_M = 0.041  # tag side length in meters (41 mm)
+TAG_SIZE_M = 0.0365  # tag side length in meters (36.5 mm)
 
 # Intrinsic parameters for the left camera
 fxL, fyL, cxL, cyL = 764.753, 759.377, 396.363, 243.605
 K_L = np.array([[fxL, 0, cxL], [0, fyL, cyL], [0, 0, 1]])
 D_L = np.array([-0.482866, 0.237679, 0.00102909, -0.0134808, -0.00693421])
 
-# AprilTag detector using OpenCV's aruco module. Use the tagStandard41h12
-# family which provides more unique IDs than 36h11.
+# AprilTag detector using OpenCV's aruco module (tagStandard36h11 family).
 DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_APRILTAG_36H11)
 PARAMS = cv2.aruco.DetectorParameters()
 DETECTOR = cv2.aruco.ArucoDetector(DICT, PARAMS)


### PR DESCRIPTION
## Summary
- update docs for 36h11 AprilTag usage
- configure calibrate and preview scripts for 36h11 tags
- detect AprilTag instead of blue marker in `new_detect.py`

## Testing
- `python3 -m py_compile new_detect.py detect_apriltag_left.py calibrate_tilt_apriltag.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d3fd48088321acd1e5c1f0aabc4b