### PR TITLE
Add gripper camera alignment step

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ ripe strawberries and coordinate the harvesting sequence.
 OpenCV. Press **n** to capture a burst of stereo frames and run detection. The
 script averages the 3D positions of the detected markers over several frames for
 more stable measurements. The left camera, right camera and detection overlay
-are displayed in separate windows.
+are displayed in separate windows.  After the initial stereo-based movement, the
+script switches to a camera mounted on the gripper (index&nbsp;4) to centre the
+strawberry before advancing the gripper.
 
 The repository also includes ``detect_apriltag_left.py`` and
 ``calibrate_tilt_apriltag.py`` for working with AprilTags. These helpers are


### PR DESCRIPTION
## Summary
- refine README with note about the gripper camera
- move robot to clearance, use gripper camera (index 4) for x/y centering, advance 4 cm, and reverse
- helper routine `fine_align_with_gripper` added

## Testing
- `python3 -m py_compile new_detect.py`

------
https://chatgpt.com/codex/tasks/task_e_68509044d0908321bb0fe57cde616802