### PR TITLE
Use single-frame detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ physically pick the strawberries. The Raspberry Pi runs Python scripts to detect
 ripe strawberries and coordinate the harvesting sequence.
 
 `new_detect.py` runs on the Raspberry Pi and shows a local interface using
-OpenCV. Press **n** to capture a burst of stereo frames and run detection. The
-script averages the 3D positions of the detected markers over several frames for
-more stable measurements. The left camera, right camera and detection overlay
+OpenCV. Press **n** to capture a pair of stereo frames and run detection. The
+script now uses a single set of frames to compute the 3D position of the
+detected markers. The left camera, right camera and detection overlay
 are displayed in separate windows.  After the initial stereo-based movement, the
 script switches to a camera mounted on the gripper (index&nbsp;4) to centre the
 strawberry before advancing the gripper. During auto centering you can press

--- a/new_detect.py
+++ b/new_detect.py
@@ -196,7 +196,7 @@ def auto_center(cam_idx=4):
 
 # ------------------------------------------------
 # 7) Main cycle with verbose debug
-NUM_FRAMES = 5
+NUM_FRAMES = 1
 
 def _avg_bbox_point(pts3d, bbox):
     x, y, w_, h_ = bbox


### PR DESCRIPTION
## Summary
- use a single stereo frame when running detection instead of averaging over 5
- document single-frame detection in README

## Testing
- `python3 -m py_compile new_detect.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1d42d848832197551f45ce75c894