### PR TITLE
Implement overshoot-aware centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ strawberry before advancing the gripper. Instead of a continuous feed, a single
 320x240 frame is captured for each correction move so centering finishes faster.
 During auto centering you can press
 **p** to pause or **h** to immediately return the robot to its start position.
+If a correction overshoots the centre, the next move uses half the initial step
+to gently settle on the target.
 
 The repository also includes ``detect_apriltag_left.py`` and
 ``calibrate_tilt_apriltag.py`` for working with AprilTags. These helpers are


### PR DESCRIPTION
## Summary
- halve auto-centering step when the previous move overshot the centre
- describe overshoot behaviour in README

## Testing
- `python3 -m py_compile new_detect.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3de01dd883218c43dfbea4ea2b64